### PR TITLE
Environment create/start/stop/remove

### DIFF
--- a/src/main/scala/rugds/sbt/DockerDevEnvironment.scala
+++ b/src/main/scala/rugds/sbt/DockerDevEnvironment.scala
@@ -177,7 +177,6 @@ trait DockerDevEnvironment {
       .flatMap(_.listFiles)
       .flatMap(repo => {
         repo.listFiles.map(image => {
-//          val imageVersion = scala.io.Source.fromFile(image.getAbsolutePath + "/version").mkString
           val envConfig = ConfigFactory.load(image.getAbsolutePath + "/rugds-env.conf")
 
           val dockerBuild  = if (new File(image.getAbsolutePath + "/Dockerfile").exists()) Some(image) else None

--- a/src/main/scala/rugds/sbt/DockerDevEnvironment.scala
+++ b/src/main/scala/rugds/sbt/DockerDevEnvironment.scala
@@ -223,7 +223,6 @@ case class EnvModule(name: String, organization: String, version: String, jarFil
     .filter(_.getName.endsWith("rugds-env.conf"))
     .map(file => {
       val image = file.getName.split('/').toSeq.init.tail.mkString("/") // remove head (docker-dependencies) and last (version)
-//      val dockerVersion = scala.io.Source.fromInputStream(x.getInputStream(file), "UTF-8").mkString.trim
       val envConfig = ConfigFactory.parseString(scala.io.Source.fromInputStream(x.getInputStream(file), "UTF-8").mkString)
 
       EnvDocker(image.split('/').head, image.split('/').last, envConfig)
@@ -235,7 +234,7 @@ case class EnvModule(name: String, organization: String, version: String, jarFil
 case class EnvDocker(repo: String, name: String, envConfig: Config, file: Option[File] = None) { // file is defined if there is Dockerfile, otherwise it represents "pure" dependency
   private val ns = "rugds.environment"
 
-  val tag     = envConfig.getString(s"$ns.version")
+  val tag     = envConfig.getString(s"$ns.tag")
   val options = Try[String] { envConfig.getString(s"$ns.options") }.getOrElse("")
 
   override def toString: String = repo match {


### PR DESCRIPTION
Commands to create, start, stop and remove the development environment. 

Removed version file, replaced with rugds-env.conf which contains (for now)

```js
rugds.environment {
  tag = "1.2.3"
  options = "-e MY_CUSTOM_ENV_VAR=test"
}
```